### PR TITLE
Improve navigation system and add navigation controller tests 

### DIFF
--- a/Sources/ImperativeNavigation/NavigationView.swift
+++ b/Sources/ImperativeNavigation/NavigationView.swift
@@ -56,7 +56,7 @@ public final class NavigationController: ObservableObject {
 /// using a coordinator pattern. It utilizes a `NavigationStack` for navigation and
 /// supports both `fullScreenCover` and `sheet` modals.
 public struct NavigationView<Root: View>: View {
-    @StateObject
+    @ObservedObject
     private var controller: NavigationController
     private let root: Root
 
@@ -69,7 +69,7 @@ public struct NavigationView<Root: View>: View {
         controller: NavigationController,
         @ViewBuilder root: () -> Root
     ) {
-        self._controller = StateObject(wrappedValue: controller)
+        self._controller = ObservedObject(wrappedValue: controller)
         self.root = root()
     }
 

--- a/Sources/ImperativeNavigation/NavigationView.swift
+++ b/Sources/ImperativeNavigation/NavigationView.swift
@@ -20,7 +20,7 @@ public final class NavigationController: ObservableObject {
     ///
     /// Note: Overloaded version of `pop()` which avoids "Generic parameter 'V' could not be inferred" error.
     public func pop<V: View>() -> V? {
-        path.popLast()?.view as? V
+        path.popLast()?.body as? V
     }
 
     /// Removes all routes from the navigation path except for the root route.
@@ -44,10 +44,10 @@ public final class NavigationController: ObservableObject {
     }
 
     /// The current navigation path represented as an array of routes.
-    @Published fileprivate var path: [Route] = []
+    @Published public fileprivate(set) var path: [Route] = []
 
     /// The currently active modal presentation, if any.
-    @Published fileprivate var modal: ModalRoute<Route>?
+    @Published public fileprivate(set) var modal: ModalRoute<Route>?
 }
 
 // MARK: - Navigation View
@@ -78,20 +78,23 @@ public struct NavigationView<Root: View>: View {
             path: $controller.path,
             root: {
                 root
-                    .navigationDestination(for: Route.self, destination: \.body)
+                    .navigationDestination(
+                        for: Route.self,
+                        destination: { AnyView($0.body) }
+                    )
                     .fullScreenCover(
                         item: Binding(
                             get: { controller.modal?.asFullScreen() },
                             set: { controller.modal = $0 }
                         ),
-                        content: \.route.body
+                        content: { AnyView($0.route.body) }
                     )
                     .sheet(
                         item: Binding(
                             get: { controller.modal?.asSheet() },
                             set: { controller.modal = $0 }
                         ),
-                        content: \.route.body
+                        content: { AnyView($0.route.body) }
                     )
             }
         )
@@ -100,38 +103,33 @@ public struct NavigationView<Root: View>: View {
 
 // MARK: - Route
 
-private struct Route: View {
-    @MainActor
-    var body: some View {
-        AnyView(erasing: view)
+public struct Route {
+    init<Content: View>(_ body: Content) {
+        self.body = body // Store same view for later casting.
+        self.viewType = String(describing: Content.self) // Keep the view name for reference.
+        self.identifier = UUID() // Each route should be unique.
     }
 
-    init<V: View>(_ view: V) {
-        self.view = view
-        self.viewType = String(describing: V.self)
-        self.identifier = UUID()
-    }
-
-    let view: any View
-    let viewType: String
-    let identifier: UUID
+    public let body: any View
+    private let viewType: String
+    private let identifier: UUID
 }
 
 // MARK: Route + Hashable Conformance
 
-extension Route: @preconcurrency Hashable {
-    func hash(into hasher: inout Hasher) {
+extension Route: Hashable {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(viewType)
         hasher.combine(identifier)
     }
 
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.viewType == rhs.viewType && lhs.identifier == rhs.identifier
     }
 }
 
 // MARK: Route + Hashable Conformance
 
-extension Route: @preconcurrency Identifiable {
-    var id: Int { hashValue }
+extension Route: Identifiable {
+    public var id: Int { hashValue }
 }

--- a/Tests/ImperativeNavigationTests/ImperativeNavigationTests.swift
+++ b/Tests/ImperativeNavigationTests/ImperativeNavigationTests.swift
@@ -1,6 +1,0 @@
-import Testing
-@testable import ImperativeNavigation
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-}

--- a/Tests/ImperativeNavigationTests/NavigationControllerTests.swift
+++ b/Tests/ImperativeNavigationTests/NavigationControllerTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import SwiftUI
+@testable import ImperativeNavigation
+
+@MainActor
+@Suite
+struct NavigationControllerTests {
+    @Test
+    func pushView() {
+        // Given
+        let navigationController = NavigationController()
+        let view = Text("Test View")
+        
+        // When
+        navigationController.push(view)
+        
+        // Then
+        #expect(navigationController.path.count == 1)
+    }
+    
+    @Test
+    func popView() {
+        // Given
+        let navigationController = NavigationController()
+        let view = Text("Test View")
+        navigationController.push(view)
+        
+        // When
+        navigationController.pop()
+        
+        // Then
+        #expect(navigationController.path.isEmpty)
+    }
+
+    @Test
+    func popViewReturnsPoppedViewType() {
+        // Given
+        let navigationController = NavigationController()
+        let view1 = View1()
+        let view2 = View2()
+        navigationController.push(view1)
+        navigationController.push(view2)
+        
+        // When
+        let poppedView2: View2? = navigationController.pop()
+        let poppedView1: View1? = navigationController.pop()
+        
+        // Then
+        #expect(poppedView2 != nil)
+        #expect(poppedView1 != nil)
+    }
+    
+    @Test
+    func popToRoot() {
+        // Given
+        let navigationController = NavigationController()
+        navigationController.push(Text("View 1"))
+        navigationController.push(Text("View 2"))
+        
+        // When
+        navigationController.popToRoot()
+        
+        // Then
+        #expect(navigationController.path.isEmpty)
+    }
+    
+    @Test
+    func presentModal() {
+        // Given
+        let navigationController = NavigationController()
+        let view = Text("Modal View")
+        
+        // When
+        navigationController.present(view)
+        
+        // Then
+        #expect(navigationController.modal != nil)
+    }
+    
+    @Test
+    func dismissModal() {
+        // Given
+        let navigationController = NavigationController()
+        navigationController.present(Text("Modal View"))
+        
+        // When
+        navigationController.dismiss()
+        
+        // Then
+        #expect(navigationController.modal == nil)
+    }
+    
+    // MARK: - Nested Views
+    
+    private struct View1: View {
+        var body: some View {
+            Text("View 1")
+        }
+    }
+
+    private struct View2: View {
+        var body: some View {
+            Text("View 2")
+        }
+    }
+}


### PR DESCRIPTION
## Summary  
This PR improves the navigation system in `ImperativeNavigation` by making `NavigationController`'s `path` and `modal` properties publicly readable, fixing type-casting issues in `pop<V: View>()`, and refining the `Route` structure for better type safety. Additionally, it replaces `StateObject` with `ObservedObject` in `NavigationView` to ensure proper ownership handling.

## Changes  
### Fixes & Enhancements  
- Update `pop<V: View>()` previously casted to `.view`, now uses `.body` for better compatibility.
- `path` and `modal` are now `public getters, allowing read access while keeping internal mutability.
- Replaced `StateObject` with `ObservedObject` to ensure the `NavigationController` is managed externally, mentioned in https://github.com/ahmdmhasn/swiftui-imperative-navigation/pull/3#discussion_r1969460080.
- Removed unnecessary `@MainActor` and `AnyView(erasing:)` wrapping.
- Made `Route` a simple struct with `body` directly storing the `View`, Change suggested in https://github.com/ahmdmhasn/swiftui-imperative-navigation/pull/3#discussion_r1969466735.

### Testing Improvements  
- **Added `NavigationControllerTests.swift`**:  
  - Tests for pushing, popping, and navigating within `NavigationController`.
  - Validates modal presentation and dismissal.
- **Removed `ImperativeNavigationTests.swift`**:  

## Testing  
- All new test cases pass.
- Manually verified modal presentation and navigation behavior.

## Checklist  
- [x] Code compiles without errors  
- [x] Tests added for new functionality  
- [x] Verified UI behavior in a test app  